### PR TITLE
🔧 Update API base URL to production endpoint

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -11,7 +11,7 @@ import {
   PaginatedResponse
 } from '../types';
 
-const API_BASE_URL = 'https://demoafya.ddnsgeek.com/api/v1';
+const API_BASE_URL = 'https://api.afyagate.com/api/v1';
 
 class ApiService {
   private api: AxiosInstance;

--- a/src/services/connectApi.ts
+++ b/src/services/connectApi.ts
@@ -1,7 +1,7 @@
 // Simple Connect-RPC service using fetch
 // This will be replaced by proper Connect-RPC client when protobuf generation is working
 
-const API_BASE_URL = 'https://demoafya.ddnsgeek.com/api/v1';
+const API_BASE_URL = 'https://api.afyagate.com/api/v1';
 
 // Cache for API responses
 const cache = new Map<string, { data: any; timestamp: number; ttl: number }>();


### PR DESCRIPTION
- Changed API_BASE_URL from demoafya.ddnsgeek.com to api.afyagate.com
- Ensures consistent API endpoint across all services
- Ready for production deployment