### PR TITLE
🔧 Update API base URL

### DIFF
--- a/src/services/connectApi.ts
+++ b/src/services/connectApi.ts
@@ -12,7 +12,7 @@ const pendingRequests = new Map<string, Promise<any>>();
 // Helper function to make Connect-RPC requests with caching
 async function makeConnectRequest<T>(
   path: string, 
-  method: 'GET' | 'POST' = 'POST', 
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' = 'POST', 
   body?: any,
   useCache: boolean = true,
   cacheTTL: number = 30000 // 30 seconds default


### PR DESCRIPTION
function only accepts 'GET' or 'POST' methods, but I used 'PUT' in the updateProfile method. Let me fix this by updating the function to support all HTTP methods.